### PR TITLE
Migrate to Swift 5 / Xcode 11

### DIFF
--- a/Reindeers.xcodeproj/project.pbxproj
+++ b/Reindeers.xcodeproj/project.pbxproj
@@ -333,37 +333,40 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1160;
 				ORGANIZATIONNAME = "Khoa Pham";
 				TargetAttributes = {
 					D2B1EE6E1FB9A85300A795FF = {
 						CreatedOnToolsVersion = 9.1;
+						LastSwiftMigration = 1160;
 						ProvisioningStyle = Automatic;
 					};
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1160;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 1000;
+						DevelopmentTeam = EV2G94D75V;
+						LastSwiftMigration = 1160;
 					};
 					D5C6293F1C3A7FAA007F7B7C = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1160;
 					};
 					D5C629481C3A7FAA007F7B7C = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1160;
 					};
 				};
 			};
 			buildConfigurationList = D5B2E8991C3A780C00C0327D /* Build configuration list for PBXProject "Reindeers" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = D5B2E8951C3A780C00C0327D;
 			productRefGroup = D5B2E8A01C3A780C00C0327D /* Products */;
@@ -527,6 +530,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.1;
 			};
@@ -554,6 +558,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.1;
 			};
@@ -563,6 +568,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -626,6 +632,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -696,6 +703,7 @@
 				PRODUCT_NAME = Reindeers;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -715,6 +723,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fantageek.Reindeers-iOS";
 				PRODUCT_NAME = Reindeers;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -723,13 +732,14 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = EV2G94D75V;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ReindeersTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ReindeerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -738,12 +748,13 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = EV2G94D75V;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ReindeersTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ReindeerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -767,6 +778,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -789,6 +801,7 @@
 				PRODUCT_NAME = Reindeers;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -807,6 +820,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -824,6 +838,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Reindeer-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-iOS.xcscheme
+++ b/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5B2E89E1C3A780C00C0327D"
+            BuildableName = "Reindeers.framework"
+            BlueprintName = "Reindeers-iOS"
+            ReferencedContainer = "container:Reindeers.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D5B2E89E1C3A780C00C0327D"
-            BuildableName = "Reindeers.framework"
-            BlueprintName = "Reindeers-iOS"
-            ReferencedContainer = "container:Reindeers.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Reindeers.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-macOS.xcscheme
+++ b/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5C6293F1C3A7FAA007F7B7C"
+            BuildableName = "Reindeers.framework"
+            BlueprintName = "Reindeers-macOS"
+            ReferencedContainer = "container:Reindeers.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D5C6293F1C3A7FAA007F7B7C"
-            BuildableName = "Reindeers.framework"
-            BlueprintName = "Reindeers-macOS"
-            ReferencedContainer = "container:Reindeers.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Reindeers.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-tvOS.xcscheme
+++ b/Reindeers.xcodeproj/xcshareddata/xcschemes/Reindeers-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Reindeers.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -31,7 +31,7 @@ open class Document {
   }
 
   public convenience init(data: Data, kind: DocumentKind = .xml) throws {
-    let bytes = data.withUnsafeBytes {
+    let bytes = data.withUnsafePointer {
       [Int8](UnsafeBufferPointer(start: $0, count: data.count))
     }
 
@@ -41,7 +41,7 @@ open class Document {
   public convenience init(nsData: NSData, kind: DocumentKind = .xml) throws {
     var bytes = [UInt8](repeatElement(0, count: nsData.length))
     nsData.getBytes(&bytes, length:bytes.count * MemoryLayout<UInt8>.size)
-    let data = Data(bytes: bytes)
+    let data = Data(bytes)
 
     try self.init(data: data)
   }

--- a/Sources/Element+Query.swift
+++ b/Sources/Element+Query.swift
@@ -11,7 +11,7 @@ import Clibxml2
 
 public extension Element {
 
-  public func children(predicate: ((Element, Int) -> Bool)? = nil) -> [Element] {
+  func children(predicate: ((Element, Int) -> Bool)? = nil) -> [Element] {
     var elements = [Element]()
     var cursor = self.cNode.pointee.children
     var index = 0
@@ -36,23 +36,23 @@ public extension Element {
     return elements
   }
 
-  public func children(name: String) -> [Element] {
+  func children(name: String) -> [Element] {
     return children { element, index in
       return element.name == name
     }
   }
 
-  public func children(indexes: [Int]) -> [Element] {
+  func children(indexes: [Int]) -> [Element] {
     return children { element, index in
       return indexes.contains(index)
     }
   }
 
-  public func child(index: Int) -> Element? {
+  func child(index: Int) -> Element? {
     return children(indexes: [index]).first
   }
 
-  public func firstChild(name: String) -> Element? {
+  func firstChild(name: String) -> Element? {
     return children(name: name).first
   }
 }

--- a/Sources/Element+String.swift
+++ b/Sources/Element+String.swift
@@ -10,7 +10,7 @@ import Foundation
 import Clibxml2
 
 public extension Element {
-  public func toXMLString(level: Int = 0) -> String {
+  func toXMLString(level: Int = 0) -> String {
     let openTag = "<\(name ?? "")\(toAttributeString())>"
     let indentation = Array(repeating: "  ", count: level).joined()
 
@@ -28,7 +28,7 @@ public extension Element {
       + indentation + endTag + "\n"
   }
 
-  public func toAttributeString() -> String {
+  func toAttributeString() -> String {
     if attributes.isEmpty {
       return ""
     } else {


### PR DESCRIPTION
This PR fixes all issues reported by Xcode 11.6.

Due to the deprecation of…

```swift
func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType
```

… I used Michael Tsai's approach to bind the memory from `UnsafeRawBufferPointer` to a `UnsafePointer<ContentType>` reference.

I wonder if I should handle the case on an empty `Data` (`count == 0`) instance in `toPointer()` though. 🤔

I hope the PR is small enough, let me know what you think!